### PR TITLE
Removing prepublish since npm install invokes it unecessarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "scripts": {
     "test": "node node_modules/mocha/bin/_mocha --timeout 10000 --compilers ts:ts-node/register --ui bdd src/**/*.test.ts",
-    "build": "webpack --config webpack.unminified.config.js --bail --progress --profile && webpack --config webpack.minified.config.js --bail --progress --profile",
-    "prepublish": "npm run test && npm run build"
+    "build": "webpack --config webpack.unminified.config.js --bail --progress --profile && webpack --config webpack.minified.config.js --bail --progress --profile"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://github.com/npm/npm/issues/3059 apparently we are another 'edge case' !