### PR TITLE
Adding bug id to comment and getCaseComments -> getComments

### DIFF
--- a/src/api/case.test.ts
+++ b/src/api/case.test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import chai = require('chai');
 const expect = chai.expect;
-import { getCaseComments } from './case';
+import { getComments } from './case';
 import {ICase_Comment__c_fields} from '../models/case';
 
 describe('Array', () => {
@@ -14,7 +14,7 @@ describe('Array', () => {
                 'Created_By_User__r.Id',
                 'Created_By_User__r.Full_Name__c'
             ];
-            return getCaseComments('00023622', fields).then((comments) => {
+            return getComments('00023622', fields).then((comments) => {
                 expect(comments.length).to.be.above(10);
                 expect(comments[0].Id).to.exist;
                 expect(comments[0].Is_Public__c).to.exist;

--- a/src/api/case.ts
+++ b/src/api/case.ts
@@ -2,7 +2,7 @@ import { fetchUri } from '../utils/fetch';
 import Env from '../utils/env';
 import {ICase_Comment__c, ICase_Comment__c_fields} from '../models/case';
 
-export function getCaseComments(caseNumber: string, fields?: ICase_Comment__c_fields): Promise<Array<ICase_Comment__c>> {
+export function getComments(caseNumber: string, fields?: ICase_Comment__c_fields): Promise<Array<ICase_Comment__c>> {
     const uri = Env.hydraHostName.clone().setPath(`${Env.pathPrefix}/case/${caseNumber}/comments`);
     if (fields && fields.length > 0) {
         uri.addQueryParam('fields', fields.join(','));

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@ import {ICase_Comment__c, ICase_Comment__c_fields} from './models/case';
 
 declare namespace hydrajs {
     namespace kase {
-        export function getCaseComments(caseNumber: string, fields?: ICase_Comment__c_fields): Promise<Array<ICase_Comment__c>>;
+        export function getComments(caseNumber: string, fields?: ICase_Comment__c_fields): Promise<Array<ICase_Comment__c>>;
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { getCaseComments } from './api/case';
+import { getComments } from './api/case';
 
 export default {
     kase: {
-        getCaseComments: getCaseComments
+        getComments: getComments
     }
 };

--- a/src/models/case.ts
+++ b/src/models/case.ts
@@ -3,8 +3,7 @@ import {IUser}                  from './user';
 import {IBugzillaComment__c}    from './bugzilla';
 
 export interface ICase_Comment__c {
-    // issueLink?: IIssueLinkResource
-
+    External_Id__c: string // Bugzilla Comment External Id
     CaseNumber__c: string;
     Case_Comment_Id__c: string;
     Case__c: string;


### PR DESCRIPTION
The naming of getCaseComments is redundant since the meaning is implied under the kase namespace.