### PR TITLE
Skedge get shift metadata endpoint call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrajs",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Client side JavaScript library to interact with Hydra",
   "main": "dist/hydra.js",
   "types": "src/index.d.ts",

--- a/src/api/shiftMetadata.ts
+++ b/src/api/shiftMetadata.ts
@@ -1,0 +1,8 @@
+import {getUri} from '../utils/fetch';
+import Env from '../utils/env';
+import {IShiftMetadata} from '../models/skedge/shiftMetadata';
+
+export function getAllShiftMetadata(): Promise<IShiftMetadata[]> {
+    const uri = Env.hydraHostName.clone().setPath(`${Env.pathPrefix}/skedge/shiftsMetadata/`);
+    return getUri<IShiftMetadata[]>(uri);
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,10 @@ declare namespace hydrajs {
         export function upsertComment(apiComment: IAPIComment): Promise<IAPIComment>;
         export function getCase(caseId: string, fields?: ICase_fields): Promise<ICase>;
     }
+
+    namespace skedge {
+        export function getAllShiftMetadata(): Promise<Array<IShiftMetadata>>;
+    }
 }
 
 export default hydrajs;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import { getComments, upsertComment, } from './api/comment';
 import { getCase } from './api/case';
+import {getAllShiftMetadata} from './api/shiftMetadata';
 
 export default {
     kase: {
         getComments: getComments,
         upsertComment: upsertComment,
         getCase: getCase,
+    },
+    skedge: {
+        getAllShiftMetadata: getAllShiftMetadata,
     }
 };

--- a/src/models/skedge/shiftMetadata.ts
+++ b/src/models/skedge/shiftMetadata.ts
@@ -1,0 +1,10 @@
+export interface IShiftMetadata {
+    id: number;
+    name: string;
+    startAt: number;
+    endAt: number;
+    createdBy: string;
+    createdAt: number;
+    updateBy: string;
+    updateAt: number;
+}


### PR DESCRIPTION
@engineersamuel @jtrantin @vrathee Please review.

https://projects.engineering.redhat.com/browse/SKEDGE-26 

As a part of this PR, we just had to add one endpoint to check connectivity to hydra. I ran Hydra server on my local and this endpoint is accessible.

Once this is merged and version bumped, I would not have to make the changes locally in skedge project for hydra js calls.

As none of the test cases are getting executed at present, we will take all the skedge related test cases in the hardening for Skedge which is planned next month.